### PR TITLE
When is no long under rest.

### DIFF
--- a/hypermedia/src/main/resources/static/webpack.config.js
+++ b/hypermedia/src/main/resources/static/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     debug: true,
     resolve: {
         alias: {
-            'when': node_dir + '/rest/node_modules/when/when.js'
+            'when': node_dir + '/when/when.js'
         }
     },
     output: {


### PR DESCRIPTION
I just started going through this tutorial and found an error where the when module could not be found.  It looks like the when.js was moved from /node_modules/rest/node_modules/when/when.js to /node_modules/when/when.js.