### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ projects: [spring-data-rest,spring-data-jpa,spring-hateoas,spring-security,sprin
 This tutorial shows a collection of apps that use Spring Data REST and its powerful backend functionality combined with React's sophisticated features to build an easy-to-grok UI.
 
 * https://www.youtube.com/watch?v=TgCr7v9tdKM[Spring Data REST] provides a fast way to build hypermedia-powered repositories.
-* http://facebook.github.io/react/index.html[React] is Facebook's solution to efficient, fast, and easy-to-use views in the land of JavaScript.
+* https://facebook.github.io/react/index.html[React] is Facebook's solution to efficient, fast, and easy-to-use views in the land of JavaScript.
 
 include::basic/README.adoc[leveloffset=+1]
 include::hypermedia/README.adoc[leveloffset=+1]

--- a/basic/README.adoc
+++ b/basic/README.adoc
@@ -10,7 +10,7 @@ In this section, you will see how to get a bare-bones Spring Data REST applicati
 
 Feel free to {sourcedir}/basic[grab the code] from this repository and follow along.
 
-If you want to do it yourself, visit http://start.spring.io and pick these items:
+If you want to do it yourself, visit https://start.spring.io and pick these items:
 
 * Rest Repositories
 * Thymeleaf
@@ -61,7 +61,7 @@ include::src/main/java/com/greglturnquist/payroll/EmployeeRepository.java[tag=co
 
 That is all that is needed! In fact, you don't even have to annotate this if it's top-level and visible. If you use your IDE and open up `CrudRepository`, you'll find a fist full of pre-built methods already defined.
 
-NOTE: You can define http://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.definition[your own repository] if you wish. Spring Data REST supports that as well.
+NOTE: You can define https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.definition[your own repository] if you wish. Spring Data REST supports that as well.
 
 == Pre-loading the demo
 
@@ -78,7 +78,7 @@ include::src/main/java/com/greglturnquist/payroll/DatabaseLoader.java[tag=code]
 * It uses constructor injection and autowiring to get Spring Data's automatically created `EmployeeRepository`.
 * The `run()` method is invoked with command line arguments, loading up your data.
 
-One of the biggest, most powerful features of Spring Data is its ability to write JPA queries for you. This not only cuts down on your development time, but also reduces the risk of bugs and errors. Spring Data http://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.details[looks at the name of methods] in a repository class and figures out the operation you need including saving, deleting, and finding.
+One of the biggest, most powerful features of Spring Data is its ability to write JPA queries for you. This not only cuts down on your development time, but also reduces the risk of bugs and errors. Spring Data https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.details[looks at the name of methods] in a repository class and figures out the operation you need including saving, deleting, and finding.
 
 That is how we can write an empty interface and inherit already built save, find, and delete operations.
 
@@ -101,13 +101,13 @@ The last step needed to get a fully operational REST API off the ground is to wr
 include::src/main/java/com/greglturnquist/payroll/ReactAndSpringDataRestApplication.java[tag=code]
 ----
 
-Assuming the previous class as well as your Maven build file were generated from http://start.spring.io, you can now launch it either by running that `main()` method inside your IDE, or type `./mvnw spring-boot:run` on the command line. (mvnw.bat for Windows users).
+Assuming the previous class as well as your Maven build file were generated from https://start.spring.io, you can now launch it either by running that `main()` method inside your IDE, or type `./mvnw spring-boot:run` on the command line. (mvnw.bat for Windows users).
 
 NOTE: If you aren't up-to-date on Spring Boot and how it works, you should consider watch one of https://www.youtube.com/watch?v=sbPSjI4tt10[Josh Long's introductory presentations]. Did it? Press on!
 
 == Touring your REST service
 
-With the app running, you can check things out on the command line using http://curl.haxx.se/[cURL] (or any other tool you like).
+With the app running, you can check things out on the command line using https://curl.haxx.se/[cURL] (or any other tool you like).
 
 ----
 $ curl localhost:8080/api
@@ -360,7 +360,7 @@ This simple layout of state, properties, and HTML shows how React lets you decla
 ====
 Does this code contain both HTML _and_ JavaScript? Yes, this is https://facebook.github.io/jsx/[JSX]. There is no requirement to use it. React can be written using pure JavaScript, but the JSX syntax is quite terse. Thanks to rapid work on the Babel.js, the transpiler provides both JSX and ES6 support all at once
 
-JSX also includes bits and pieces of http://es6-features.org/#Constants[ES6]. The one used in the code is the http://es6-features.org/#ExpressionBodies[arrow function]. It avoids creating a nested function() with its own scoped *this*, and avoids needing a http://stackoverflow.com/a/962040/28214[*self* variable].
+JSX also includes bits and pieces of http://es6-features.org/#Constants[ES6]. The one used in the code is the http://es6-features.org/#ExpressionBodies[arrow function]. It avoids creating a nested function() with its own scoped *this*, and avoids needing a https://stackoverflow.com/a/962040/28214[*self* variable].
 
 Worried about mixing logic with your structure? React's APIs encourage nice, declarative structure combined with state and properties. Instead of mixing a bunch of unrelated JavaScript and HTML, React encourages building simple components with small bits of related state and properties that work well together. It lets you look at a single component and understand the design. Then they are easy to combine together for bigger structures.
 ====

--- a/basic/src/main/js/api/uriTemplateInterceptor.js
+++ b/basic/src/main/js/api/uriTemplateInterceptor.js
@@ -5,7 +5,7 @@ define(function(require) {
 
 	return interceptor({
 		request: function (request /*, config, meta */) {
-			/* If the URI is a URI Template per RFC 6570 (http://tools.ietf.org/html/rfc6570), trim out the template part */
+			/* If the URI is a URI Template per RFC 6570 (https://tools.ietf.org/html/rfc6570), trim out the template part */
 			if (request.path.indexOf('{') === -1) {
 				return request;
 			} else {

--- a/basic/src/main/resources/templates/index.html
+++ b/basic/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head lang="en">
     <meta charset="UTF-8"/>
     <title>ReactJS + Spring Data REST</title>

--- a/conditional/README.adoc
+++ b/conditional/README.adoc
@@ -24,7 +24,7 @@ include::src/main/java/com/greglturnquist/payroll/Employee.java[tag=code]
 
 * The *version* field is annotated with `javax.persistence.Version`. It causes a value to be automatically stored and updated everytime a row is inserted and updated.
 
-When fetching an individual resource (not a collection resource), Spring Data REST will automatically add an http://tools.ietf.org/html/rfc7232#section-2.3[ETag response header] with the value of this field.
+When fetching an individual resource (not a collection resource), Spring Data REST will automatically add an https://tools.ietf.org/html/rfc7232#section-2.3[ETag response header] with the value of this field.
 
 == Fetching individual resources and their headers
 
@@ -71,7 +71,7 @@ The *id* field is built differently. There is only one CreateDialog link on the 
 
 === Handling user input
 
-The submit button is linked to the component's `handleSubmit()` function. This handily uses `React.findDOMNode()` to extract the details of the pop-up using http://facebook.github.io/react/docs/more-about-refs.html[React refs]. 
+The submit button is linked to the component's `handleSubmit()` function. This handily uses `React.findDOMNode()` to extract the details of the pop-up using https://facebook.github.io/react/docs/more-about-refs.html[React refs]. 
 
 After the input values are extracted and loaded into the `updatedEmployee` object, the top-level `onUpdate()` method is invoked. This continues React's style of one-way binding where the functions to call are pushed from upper level components into the lower level ones. This way, state is still managed at the top.
 
@@ -85,7 +85,7 @@ So you've gone to all this effort to embed versioning in the data model. Spring 
 include::src/main/js/app.js[tag=update]
 ----
 
-PUT with an http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24[If-Match request header] causes Spring Data REST to check the value against the current version. If the incoming *If-Match* value doesn't match the data store's version value, Spring Data REST will fail with an *HTTP 412 Precondition Failed*.
+PUT with an https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24[If-Match request header] causes Spring Data REST to check the value against the current version. If the incoming *If-Match* value doesn't match the data store's version value, Spring Data REST will fail with an *HTTP 412 Precondition Failed*.
 
 NOTE: The spec for https://promisesaplus.com/[Promises/A+] actually defines their API as `then(successFunction, errorFunction)`. So far, you've only seen it used with success functions. In the code fragment above, there are two functions. The success function invokes `loadFromServer` while the error function displays a browser alert about the stale data.
 
@@ -103,7 +103,7 @@ include::src/main/js/app.js[tag=employee]
 
 In this section, you switch from using the collection resource to individual resources. The fields for an employee record are now found at `this.props.employee.entity`. It gives us access to `this.props.employee.headers` where we can find ETags. 
 
-There are other headers supported by Spring Data REST (like http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29[Last-Modified]) which aren't part of this series. So structuring your data this way is handy.
+There are other headers supported by Spring Data REST (like https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29[Last-Modified]) which aren't part of this series. So structuring your data this way is handy.
 
 IMPORTANT: The structure of `.entity` and `.headers` is only pertinent when using https://github.com/cujojs/rest[rest.js] as the REST library of choice. If you use a different library, you will have to adapt as necessary.
 

--- a/conditional/src/main/js/api/uriTemplateInterceptor.js
+++ b/conditional/src/main/js/api/uriTemplateInterceptor.js
@@ -5,7 +5,7 @@ define(function(require) {
 
 	return interceptor({
 		request: function (request /*, config, meta */) {
-			/* If the URI is a URI Template per RFC 6570 (http://tools.ietf.org/html/rfc6570), trim out the template part */
+			/* If the URI is a URI Template per RFC 6570 (https://tools.ietf.org/html/rfc6570), trim out the template part */
 			if (request.path.indexOf('{') === -1) {
 				return request;
 			} else {

--- a/conditional/src/main/resources/templates/index.html
+++ b/conditional/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head lang="en">
     <meta charset="UTF-8"/>
     <title>ReactJS + Spring Data REST</title>

--- a/events/README.adoc
+++ b/events/README.adoc
@@ -23,7 +23,7 @@ This bring in Spring Boot's WebSocket starter.
 
 == Configuring WebSockets with Spring
 
-http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#websocket[Spring comes with powerful WebSocket support]. One thing to recognize is that a WebSocket is a very low level protocol. It does little more than offer the means to transmit data between client and server. The recommendation is to use a sub-protocol (STOMP for this section) to actually encode data and routes.
+https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#websocket[Spring comes with powerful WebSocket support]. One thing to recognize is that a WebSocket is a very low level protocol. It does little more than offer the means to transmit data between client and server. The recommendation is to use a sub-protocol (STOMP for this section) to actually encode data and routes.
 
 The follow code is used to configure WebSocket support on the server side:
 
@@ -42,7 +42,7 @@ With this configuration, it's now possible to tap into Spring Data REST events a
 
 == Subscribing to Spring Data REST events
 
-Spring Data REST generates several http://docs.spring.io/spring-data/rest/docs/current/reference/html/#events[application events] based on actions occurring on the repositories. The follow code shows how to subscribe to some of these events:
+Spring Data REST generates several https://docs.spring.io/spring-data/rest/docs/current/reference/html/#events[application events] based on actions occurring on the repositories. The follow code shows how to subscribe to some of these events:
 
 [source,java]
 ----

--- a/events/src/main/js/api/uriTemplateInterceptor.js
+++ b/events/src/main/js/api/uriTemplateInterceptor.js
@@ -5,7 +5,7 @@ define(function(require) {
 
 	return interceptor({
 		request: function (request /*, config, meta */) {
-			/* If the URI is a URI Template per RFC 6570 (http://tools.ietf.org/html/rfc6570), trim out the template part */
+			/* If the URI is a URI Template per RFC 6570 (https://tools.ietf.org/html/rfc6570), trim out the template part */
 			if (request.path.indexOf('{') === -1) {
 				return request;
 			} else {

--- a/events/src/main/resources/templates/index.html
+++ b/events/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head lang="en">
     <meta charset="UTF-8"/>
     <title>ReactJS + Spring Data REST</title>

--- a/hypermedia/README.adoc
+++ b/hypermedia/README.adoc
@@ -9,7 +9,7 @@ Feel free to {sourcedir}/hypermedia[grab the code] from this repository and foll
 
 == In the beginning there was data...and then there was REST
 
-[quote, Roy T. Fielding, http://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven]
+[quote, Roy T. Fielding, https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven]
 I am getting frustrated by the number of people calling any HTTP-based interface a REST API. Today’s example is the SocialSite REST API. That is RPC. It screams RPC....What needs to be done to make the REST architectural style clear on the notion that hypertext is a constraint? In other words, if the engine of application state (and hence the API) is not being driven by hypertext, then it cannot be RESTful and cannot be a REST API. Period. Is there some broken manual somewhere that needs to be fixed?
 
 So, what exactly ARE hypermedia controls, i.e. hypertext, and how can you use them? To find out, let's take a step back and look at the core mission of REST.
@@ -163,7 +163,7 @@ Sometimes, a rel by itself isn't enough. In this fragment of code, it also plugs
 
 == Grabbing JSON Schema metadata
 
-After navigating to *employees* with the size-based query, the *employeeCollection* is at your fingertips. In the previous section, we called it day and displayed that data inside `<EmployeeList />`. Today, you are performing another call to grab some http://json-schema.org/[JSON Schema metadata] found at `/api/profile/employees/`.
+After navigating to *employees* with the size-based query, the *employeeCollection* is at your fingertips. In the previous section, we called it day and displayed that data inside `<EmployeeList />`. Today, you are performing another call to grab some https://json-schema.org/[JSON Schema metadata] found at `/api/profile/employees/`.
 
 You can see the data yourself:
 
@@ -190,7 +190,7 @@ $ curl http://localhost:8080/api/profile/employees -H "Accept:application/schema
   },
   "definitions" : { },
   "type" : "object",
-  "$schema" : "http://json-schema.org/draft-04/schema#"
+  "$schema" : "https://json-schema.org/draft-04/schema#"
 }
 ----
 

--- a/hypermedia/src/main/js/api/uriTemplateInterceptor.js
+++ b/hypermedia/src/main/js/api/uriTemplateInterceptor.js
@@ -5,7 +5,7 @@ define(function(require) {
 
 	return interceptor({
 		request: function (request /*, config, meta */) {
-			/* If the URI is a URI Template per RFC 6570 (http://tools.ietf.org/html/rfc6570), trim out the template part */
+			/* If the URI is a URI Template per RFC 6570 (https://tools.ietf.org/html/rfc6570), trim out the template part */
 			if (request.path.indexOf('{') === -1) {
 				return request;
 			} else {

--- a/hypermedia/src/main/resources/templates/index.html
+++ b/hypermedia/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head lang="en">
     <meta charset="UTF-8"/>
     <title>ReactJS + Spring Data REST</title>

--- a/security/README.adoc
+++ b/security/README.adoc
@@ -73,7 +73,7 @@ include::src/main/java/com/greglturnquist/payroll/EmployeeRepository.java[tag=co
 
 `@PreAuthorize` at the top of the interface restricts access to people with *ROLE_MANAGER*.
 
-On `save()`, either the employee's manager is null (initial creation of a new employee when no manager has been assigned), or the employee's manager's name matches the currently authenticated user's name. Here you are using http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#el-access[Spring Security's SpEL expressions] to define access. It comes with a handy "?." property navigator to handle null checks. It's also important to note using the `@Param(...)` on the arguments to link HTTP operations with the methods.
+On `save()`, either the employee's manager is null (initial creation of a new employee when no manager has been assigned), or the employee's manager's name matches the currently authenticated user's name. Here you are using https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#el-access[Spring Security's SpEL expressions] to define access. It comes with a handy "?." property navigator to handle null checks. It's also important to note using the `@Param(...)` on the arguments to link HTTP operations with the methods.
 
 On `delete()`, the method either has access to the employee, or in the event it only has an id, then it must find the *employeeRepository* in the application context, perform a `findOne(id)`, and then check the manager against the currently authenticated user.
 
@@ -104,7 +104,7 @@ include::src/main/java/com/greglturnquist/payroll/SecurityConfiguration.java[tag
 This code has a lot of complexity in it, so let's walk through it, first talking about the annotations and APIs. Then we'll discuss the security policy it defines.
 
 * `@EnableWebSecurity` tells Spring Boot to drop its autoconfigured security policy and use this one instead. For quick demos, autoconfigured security is okay. But for anything real, you should write the policy yourself.
-* `@EnableGlobalMethodSecurity` turns on method-level security with Spring Security's sophisticated http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#el-pre-post-annotations[@Pre and @Post annotations].
+* `@EnableGlobalMethodSecurity` turns on method-level security with Spring Security's sophisticated https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#el-pre-post-annotations[@Pre and @Post annotations].
 * It extends `WebSecurityConfigurerAdapter`, a handy base class to write policy.
 * It autowired the `SpringDataJpaUserDetailsService` by field inject and then plugs it in via the `configure(AuthenticationManagerBuilder)` method. The `PASSWORD_ENCODER` from `Manager` is also setup.
 * The pivotal security policy is written in pure Java with the `configure(HttpSecurity)`.
@@ -219,7 +219,7 @@ If a field is shown in the data output, it is safe to assume it has an entry in 
     ...
   },
   ...
-  "$schema" : "http://json-schema.org/draft-04/schema#"
+  "$schema" : "https://json-schema.org/draft-04/schema#"
 }
 ----
 

--- a/security/src/main/js/api/uriTemplateInterceptor.js
+++ b/security/src/main/js/api/uriTemplateInterceptor.js
@@ -5,7 +5,7 @@ define(function(require) {
 
 	return interceptor({
 		request: function (request /*, config, meta */) {
-			/* If the URI is a URI Template per RFC 6570 (http://tools.ietf.org/html/rfc6570), trim out the template part */
+			/* If the URI is a URI Template per RFC 6570 (https://tools.ietf.org/html/rfc6570), trim out the template part */
 			if (request.path.indexOf('{') === -1) {
 				return request;
 			} else {

--- a/security/src/main/resources/templates/index.html
+++ b/security/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head lang="en">
     <meta charset="UTF-8"/>
     <title>ReactJS + Spring Data REST</title>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://es6-features.org/ (200) with 3 occurrences could not be migrated:  
   ([https](https://es6-features.org/) result SSLHandshakeException).
* [ ] http://know.cujojs.com/tutorials/promises/consuming-promises (200) with 1 occurrences could not be migrated:  
   ([https](https://know.cujojs.com/tutorials/promises/consuming-promises) result SSLHandshakeException).
* [ ] http://stateless.co/hal_specification.html (200) with 2 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) result SSLException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://curl.haxx.se/ with 1 occurrences migrated to:  
  https://curl.haxx.se/ ([https](https://curl.haxx.se/) result 200).
* [ ] http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/) result 200).
* [ ] http://json-schema.org/ with 1 occurrences migrated to:  
  https://json-schema.org/ ([https](https://json-schema.org/) result 200).
* [ ] http://json-schema.org/draft-04/schema with 2 occurrences migrated to:  
  https://json-schema.org/draft-04/schema ([https](https://json-schema.org/draft-04/schema) result 200).
* [ ] http://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven with 1 occurrences migrated to:  
  https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven ([https](https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven) result 200).
* [ ] http://stackoverflow.com/a/962040/28214 with 1 occurrences migrated to:  
  https://stackoverflow.com/a/962040/28214 ([https](https://stackoverflow.com/a/962040/28214) result 200).
* [ ] http://start.spring.io with 2 occurrences migrated to:  
  https://start.spring.io ([https](https://start.spring.io) result 200).
* [ ] http://tools.ietf.org/html/rfc6570 with 5 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6570 ([https](https://tools.ietf.org/html/rfc6570) result 200).
* [ ] http://tools.ietf.org/html/rfc7232 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7232 ([https](https://tools.ietf.org/html/rfc7232) result 200).
* [ ] http://www.thymeleaf.org with 5 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://docs.spring.io/spring-data/jpa/docs/current/reference/html/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-data/jpa/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring-data/rest/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/rest/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/rest/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 301).
* [ ] http://facebook.github.io/react/docs/more-about-refs.html with 1 occurrences migrated to:  
  https://facebook.github.io/react/docs/more-about-refs.html ([https](https://facebook.github.io/react/docs/more-about-refs.html) result 301).
* [ ] http://facebook.github.io/react/index.html with 1 occurrences migrated to:  
  https://facebook.github.io/react/index.html ([https](https://facebook.github.io/react/index.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 3 occurrences
* http://localhost:8080/api/employees with 3 occurrences
* http://localhost:8080/api/employees/1 with 4 occurrences
* http://localhost:8080/api/employees/2 with 2 occurrences
* http://localhost:8080/api/employees?page=0&size=2 with 3 occurrences
* http://localhost:8080/api/employees?page=1&size=2 with 2 occurrences
* http://localhost:8080/api/employees?page=2&size=2 with 3 occurrences
* http://localhost:8080/api/profile with 1 occurrences
* http://localhost:8080/api/profile/employees with 1 occurrences