### PR TITLE
Spring Boot 2.0 → 2.1 and minor dependency to be compliant with Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.5.RELEASE</version>
+		<version>2.1.4.RELEASE</version>
 		<relativePath/>
 	</parent>
 	

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -49,7 +49,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.thymeleaf.extras</groupId>
-			<artifactId>thymeleaf-extras-springsecurity4</artifactId>
+			<artifactId>thymeleaf-extras-springsecurity5</artifactId>
 		</dependency>
 		<!-- end::security[] -->
 		<dependency>


### PR DESCRIPTION
It's not just an upgrade, currently the source code is not working with Java 11+, with Java 9+ is still compatible but with warnings, see #91

I tested the changes against Java 8 and Java 11 and it worked.