### PR TITLE
fix level 0 section error and update the header

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,6 @@
----
-tags: [rest,hateoas,data,react,security]
-projects: [spring-data-rest,spring-data-jpa,spring-hateoas,spring-security,spring-boot,]
----
+:doctype: book
+:tags: [rest,hateoas,data,react,security]
+:projects: [spring-data-rest,spring-data-jpa,spring-hateoas,spring-security,spring-boot,]
 :toc: left
 :icons: font
 :source-highlighter: prettify

--- a/tohtml
+++ b/tohtml
@@ -2,17 +2,12 @@
 
 asciidoctor -a linkcss -s README.adoc
 
-cd basic
-asciidoctor -a linkcss -s README.adoc
+asciidoctor -a linkcss -s basic/README.adoc
 
-cd ../hypermedia
-asciidoctor -a linkcss -s README.adoc
+asciidoctor -a linkcss -s hypermedia/README.adoc
 
-cd ../conditional
-asciidoctor -a linkcss -s README.adoc
+asciidoctor -a linkcss -s conditional/README.adoc
 
-cd ../events
-asciidoctor -a linkcss -s README.adoc
+asciidoctor -a linkcss -s events/README.adoc
 
-cd ../security
-asciidoctor -a linkcss -s README.adoc
+asciidoctor -a linkcss -s security/README.adoc


### PR DESCRIPTION
Obvious Fix for #106 

Added `:doctype:book` to enable level 0 sections.
Update the header from the old Markdown format to native asciidoc, it was not parsed properly by IDEs.
