### PR TITLE
Fixes #112 : Modifications in JavaScript files weren't reflected

### DIFF
--- a/basic/package.json
+++ b/basic/package.json
@@ -25,7 +25,7 @@
     "rest": "^1.3.1"
   },
   "scripts": {
-    "watch": "webpack --watch -d"
+    "watch": "webpack --watch -d --output ./target/classes/static/built/bundle.js"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/conditional/package.json
+++ b/conditional/package.json
@@ -25,7 +25,7 @@
     "rest": "^1.3.1"
   },
   "scripts": {
-    "watch": "webpack --watch -d"
+    "watch": "webpack --watch -d --output ./target/classes/static/built/bundle.js"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/events/package.json
+++ b/events/package.json
@@ -27,7 +27,7 @@
     "stompjs": "^2.3.3"
   },
   "scripts": {
-    "watch": "webpack --watch -d"
+    "watch": "webpack --watch -d --output ./target/classes/static/built/bundle.js"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/hypermedia/package.json
+++ b/hypermedia/package.json
@@ -25,7 +25,7 @@
     "rest": "^1.3.1"
   },
   "scripts": {
-    "watch": "webpack --watch -d"
+    "watch": "webpack --watch -d --output ./target/classes/static/built/bundle.js"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/security/package.json
+++ b/security/package.json
@@ -27,7 +27,7 @@
     "stompjs": "^2.3.3"
   },
   "scripts": {
-    "watch": "webpack --watch -d"
+    "watch": "webpack --watch -d --output ./target/classes/static/built/bundle.js"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",


### PR DESCRIPTION
…despite running "npm run-script watch". In detail, fixes this:

1. git clone https://github.com/spring-guides/tut-react-and-spring-data-rest.git
2. Run any project with spring-boot:run via IntelliJ Idea
3. Open http://localhost:8080/. App works.
4. Run npm run-script watch in the project directory. Watching starts OK.
5. Change app.js and save it. Watch triggers.
6. Open http://localhost:8080/ and hard-refresh the page. Changes from the previous step don't appear.