### PR TITLE
Fixes frontend-maven-plugin snippet in `basic` module.

### DIFF
--- a/basic/README.adoc
+++ b/basic/README.adoc
@@ -249,7 +249,7 @@ This section contains the barebones information to get the JavaScript bits off t
 ====
 [source,xml,indent=0]
 ----
-include::pom.xml[tag=frontend-maven-plugin]
+include::../pom.xml[tag=frontend-maven-plugin]
 ----
 ====
 


### PR DESCRIPTION
It looks like, to maintain sanity, the configuration for the
frontend-maven-plugin was defined in the root tutorial pom and the
configuration is inherited by all the submodules, like `basic`.

The problem was that one following along with the project needs that
configuration.

Now, we show the full configuration instead by including the
frontend-maven-plugin configuration from the root POM instead of
from `basic`'s POM.

Should resolve some concerns described in issues  #124, #128.
